### PR TITLE
Memory usage improvement

### DIFF
--- a/mysqldump.php
+++ b/mysqldump.php
@@ -50,6 +50,7 @@ class MySQLDump
     {
         mysql_connect($this->host, $this->user, $this->pass) or die(mysql_error());
         mysql_select_db($this->db) or die(mysql_error());
+        mysql_query("SET NAMES utf8"); // Just for shure :)
     }
 
     public function list_tables()


### PR DESCRIPTION
There is no need of storing $sql_file and $output in memory, this will only make this script unusable on large databases ("Fatal error: Allowed memory size of XXX bytes exhausted" bug). Should write stuff directly to file.
