### PR TITLE
2 in 1: ";" after "create table" and proper escape

### DIFF
--- a/mysqldump.php
+++ b/mysqldump.php
@@ -81,7 +81,7 @@ class MySQLDump
                     $vrednost = $row[$i];
 
                     if (!is_integer($vrednost))
-                        $vrednost = "'".addslashes($vrednost)."'";
+                        $vrednost = "'".mysql_real_escape_string($vrednost)."'";
 
                     $buffer .= $vrednost.', ';
                 }
@@ -109,7 +109,7 @@ class MySQLDump
         
         $sql = mysql_query("SHOW CREATE TABLE `$tablename`") or die(mysql_error());        
         if ($row = mysql_fetch_array($sql)) {
-           $this->write( $row['Create Table']."\n\n" );
+           $this->write( $row['Create Table'].";\n\n" );
         }
     }
 }


### PR DESCRIPTION
1. Sorry, forgot to ";" in CREATE TABLE routine.
2. Replaced addslashes with mysql_real_escape_string (http://php.net/manual/en/function.mysql-real-escape-string.php)
