### PR TITLE
Internationalization issue with count(STRING)

### DIFF
--- a/mysqldump.php
+++ b/mysqldump.php
@@ -70,23 +70,16 @@ class MySQLDump
 
     public function list_values($tablename)
     {
-        $sql = mysql_query("SELECT * FROM `$tablename`");
         $this->write("\n\n-- Dumping data for table: $tablename\n\n");
+        $sql = mysql_query("SELECT * FROM `$tablename`");
         if ($sql !== false) {
             while ($row = mysql_fetch_array($sql)) {
                 $broj_polja = count($row) / 2;
-                $this->write("INSERT INTO `$tablename` VALUES(");
-                $buffer = '';
-                for ($i=0;$i < $broj_polja;$i++) {
-                    $vrednost = $row[$i];
-
-                    if (!is_integer($vrednost))
-                        $vrednost = "'".mysql_real_escape_string($vrednost)."'";
-
-                    $buffer .= $vrednost.', ';
+                $vals = array();
+                for ($i=0; $i < $broj_polja; $i++) {
+                    $vals[] = "'".mysql_real_escape_string($row[$i])."'";
                 }
-                $buffer = substr($buffer,0,count($buffer)-3);
-                $this->write($buffer . ");\n");
+                $this->write("INSERT INTO `$tablename` VALUES(".implode(", ",$vals).");\n");
             }
         } else {
             $this->write("-- Could not list values of {$tablename}\n\n");


### PR DESCRIPTION
Relying on substr($buffer,0,count($buffer)-3) in some systems leads to broken insert statements because of multibyte chars issues (http://www.php.net/manual/en/intro.mbstring.php). Moving to mb_substr and mb_strlen is not a solution, so I've completely rewrote this to be done without any string operators.
Also I've removed is_integer check, cause it will always return false here (http://www.php.net/manual/en/function.is-int.php). To test if a variable is a number or a numeric string, we must use is_numeric(). Anyway, there is no need of this, cause MySQL is doing automatic conversion on insert. 
