### PR TITLE
Added nodata option to dump only database structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Or without the `'auto' => true` to load it on demand:
 
     $dump = new MySQLDump('forum','forum_user','forum_pass','localhost');
     $dump->start('forum_dump.sql');
+    $dump->nodata = false;
     $dump->compress = true;
     $dump->droptableifexists = true;
     $dump->start('forum_dump_with_drops.sql.gz');    

--- a/mysqldump.php
+++ b/mysqldump.php
@@ -19,6 +19,7 @@ class MySQLDump
     public $filename = 'dump.sql';
 
     // Usable switch
+    public $nodata = false;
     public $droptableifexists = false;
     public $include = array();
     public $exclude = array();
@@ -103,7 +104,7 @@ class MySQLDump
                 continue;
             }
             $is_table = $this->getTableStructure($table);
-            if ($is_table == true) {
+            if (true === $is_table && false === $this->nodata) {
                 $this->listValues($table);
             }
         }


### PR DESCRIPTION
Implemented the nodata attribute . From mysqldump documentation:

When true, do not write any table row information (that is, do not dump table contents). This is useful if you want to dump only the CREATE TABLE statement for the table (for example, to create an empty copy of the table by loading the dump file). 
