### PR TITLE
Issue #19 Adjust options names in accordance with original ones, using arrays with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ Or without the `'auto' => true` to load it on demand:
     <?php
 
     $dumpSettings = array(
-	'include-tables' => array('table1', 'table2'),
-	'exclude-tables' => array('table3', 'table4),
-	'compress' => true,
-	'add-drop-table' => true,
-	'no-data' => true);
+        'include-tables' => array('table1', 'table2'),
+        'exclude-tables' => array('table3', 'table4'),
+        'compress' => true,
+        'add-drop-table' => true,
+        'no-data' => true);
 
     $dump = new MySQLDump('forum','forum_user','forum_pass','localhost', $dumpSettings);
     $dump->start('forum_dump.sql.gz');
-          
+
 ## Advanced usage
 
     <?php
@@ -63,7 +63,7 @@ Or without the `'auto' => true` to load it on demand:
             return "Backup complete.";
         }
     }
-    
+
 
 ## Credits
 

--- a/mysqldump.php
+++ b/mysqldump.php
@@ -26,11 +26,12 @@ class MySQLDump
     private $views = array();
     private $db_handler;
     private $file_handler;
-    private $defaultSettings = array('no-data' => false,
-	'add-drop-table' => false,
-	'include-tables' => array(),
-	'exclude-tables' => array(),
-	'compress' => false);
+    private $defaultSettings = array(
+        'no-data' => false,
+        'add-drop-table' => false,
+        'include-tables' => array(),
+        'exclude-tables' => array(),
+        'compress' => false);
 
     /**
      * Constructor of MySQLDump
@@ -48,7 +49,7 @@ class MySQLDump
         $this->host = $host;
         $this->settings = $this->extend($this->defaultSettings, $settings);
     }
-    
+
     /**
      * jquery style extend, merges arrays (without errors if the passed values are not arrays)
      * extend($defaults, $options);
@@ -56,16 +57,16 @@ class MySQLDump
      * @return array $extended
      */
     public function extend() {
-	$args = func_get_args();
+        $args = func_get_args();
         $extended = array();
         if( is_array($args) && count($args)>0 ) {
-    	    foreach($args as $array) {
-        	if(is_array($array)) {
-            	    $extended = array_merge($extended, $array);
-        	}
-    	    }
-	}
-	return $extended;
+            foreach($args as $array) {
+                if(is_array($array)) {
+                    $extended = array_merge($extended, $array);
+                }
+            }
+        }
+        return $extended;
     }
 
     /**


### PR DESCRIPTION
Totally agree, options names should follow mysqldump parameters keys whenever possible. This patch renames options and implements an array to pass config options to MYSQLDump class.

   $dumpSettings = array(
        'include-tables' => array('table1', 'table2'),
        'exclude-tables' => array('table3', 'table4'),
        'compress' => true,
        'add-drop-table' => true,
        'no-data' => true);

 $dump = new MySQLDump('forum','forum_user','forum_pass','localhost', $dumpSettings);

ps.- following PHP-FIG in new code.
