### PR TITLE
Fix #21 Add several options from mysqldump (add-drop-table, single-transaction, lock-tables, add-locks, extended-insert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ Or without the `'auto' => true` to load it on demand:
         'include-tables' => array('table1', 'table2'),
         'exclude-tables' => array('table3', 'table4'),
         'compress' => true,
-        'add-drop-table' => true,
-        'no-data' => true);
+        'no-data' => false,             /* http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_no-data */
+        'add-drop-table' => false,      /* http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_add-drop-table */
+        'single-transaction' => true,   /* http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_single-transaction */
+        'lock-tables' => false,         /* http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_lock-tables */
+        'add-locks' => true,            /* http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_add-locks */
+        'extended-insert' => true       /* http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_extended-insert */
 
     $dump = new MySQLDump('forum','forum_user','forum_pass','localhost', $dumpSettings);
     $dump->start('forum_dump.sql.gz');


### PR DESCRIPTION
Speed up to x3 with big databases (>2Gb) when using extended-insert, single-transaction, lock-tables, add-locks...
