### PR TITLE
Clean code and prevent incomplete backups

### DIFF
--- a/src/Clouddueling/mysqldump.php
+++ b/src/Clouddueling/mysqldump.php
@@ -161,7 +161,17 @@ class Mysqldump
                 (! empty($this->_settings['include-tables']) &&
                 in_array(current($row), $this->_settings['include-tables'], true))) {
                 array_push($this->_tables, current($row));
+                // remove tables from include-tables array.
+                if ( ($key = array_search(current($row), $this->_settings['include-tables'])) !== false ) {
+                    unset($this->_settings['include-tables'][$key]);
+                }
             }
+        }
+
+        // If there still are some tables in include-tables array, that means
+        // that some tables weren't found. Give proper error and exit.
+        if ( 0 < count($this->_settings['include-tables']) ) {
+            throw new Exception("Table (" . implode(",", $this->_settings['include-tables']) . ") not found in database", 4);
         }
 
         // Disable checking foreign keys


### PR DESCRIPTION
Abort execution when there is a table defined in table-include that is not found in the database. 

Without this patch, dumps may fail silently without user noticing that backup was empty or missing some table.

Mimics mysqldump behaviour.
