### PR TITLE
Changed constructor paramter settings to default to a blank array

### DIFF
--- a/src/Clouddueling/Mysqldump/Mysqldump.php
+++ b/src/Clouddueling/Mysqldump/Mysqldump.php
@@ -39,7 +39,7 @@ class Mysqldump
      * @return null
      */
     public function __construct($db = '', $user = '', $pass = '',
-        $host = 'localhost', $type = "mysql", $settings = null,
+        $host = 'localhost', $type = "mysql", $settings = array(),
         $pdoOptions = array(PDO::ATTR_PERSISTENT => true,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"))


### PR DESCRIPTION
When constructing a Mysqldump with minimalist parameters, you get an exception when array_replace_recursive attempts to compare an array and a null. This is easily fixed by making the default value for the $settings parameter a blank array instead of null.

For example:

$dump = new Mysqldump($database, $user, $password);

Throws an exception.
