### PR TITLE
Added example for json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,16 @@ Using [Composer](http://getcomposer.org):
 
 ```
 $ composer require ifsnop/mysqldump-php:1.*
+
 ```
+
+Or via json file:
+
+````
+"require": {
+        "ifsnop/mysqldump-php":"1.*"
+}
+````
 
 Using [Curl](http://curl.haxx.se):
 


### PR DESCRIPTION
added the following example for using composer via a json file

```
"require": {
        "ifsnop/mysqldump-php":"1.*"
 }
```
