### PR TITLE
Missing leading zeros in numeric string values

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -351,8 +351,9 @@ class Mysqldump
         foreach ($arr as $val) {
             if (is_null($val)) {
                 $ret[] = "NULL";
-            } elseif (ctype_digit($val)) {
-                // faster than "(string) intval($val) === $val"
+            } elseif (ctype_digit($val) && (string) intval($val) === $val) {
+            	// Since "(string) intval($val) === $val" is slower, first check ctype_digit, then run comparison
+            	// We can't use ctype_digit alone, as this will trim off leading zeros on string values
                 // but will quote negative integers (not a big deal IMHO)
                 $ret[] = $val;
             } else {


### PR DESCRIPTION
This fix adds an additional check for numeric values, as you MUST quote
numbers that have leading zeros, or else those zeros will be trimmed
off. This is very problematic with string fields that only contain
numbers, but must remain strings with leading zeros.
