### PR TITLE
Added method to retrieve written dump filename

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -270,6 +270,16 @@ class Mysqldump
     }
 
     /**
+     * Returns written archive filename
+     *
+     * @return string
+     */
+    public function getFilename()
+    {
+        return $this->compressManager->getArchiveFilename();
+    }
+
+    /**
      * Returns header for dump file
      *
      * @return string
@@ -719,6 +729,8 @@ abstract class CompressMethod
 
 abstract class CompressManagerFactory
 {
+    protected $archiveFilename;
+
     /**
      * @param string $c
      * @return CompressBzip2|CompressGzip|CompressNone
@@ -733,6 +745,11 @@ abstract class CompressManagerFactory
         $method =  __NAMESPACE__ . "\\" . "Compress" . $c;
 
         return new $method;
+    }
+
+    public function getArchiveFilename()
+    {
+        return $this->archiveFilename;
     }
 }
 
@@ -749,7 +766,8 @@ class CompressBzip2 extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->fileHandler = bzopen($filename . ".bz2", "w");
+        $this->archiveFilename = $filename . ".bz2";
+        $this->fileHandler = bzopen($this->archiveFilename, "w");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
         }
@@ -784,7 +802,8 @@ class CompressGzip extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->fileHandler = gzopen($filename . ".gz", "wb");
+        $this->archiveFilename = $filename . ".gz";
+        $this->fileHandler = gzopen($this->archiveFilename, "wb");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
         }
@@ -812,7 +831,8 @@ class CompressNone extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->fileHandler = fopen($filename, "wb");
+        $this->archiveFilename = $filename;
+        $this->fileHandler = fopen($this->archiveFilename, "wb");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
         }
@@ -1041,7 +1061,7 @@ abstract class TypeAdapterFactory
     {
         return array();
     }
-    
+
     public function backup_parameters()
     {
         return PHP_EOL;


### PR DESCRIPTION
Added method Mysqldump::getFilename() to be able to get the written compressed archive filename, depending on the chosen compression method.

Because if you want to perform post operations on your dump file after it was created, you need to know its real filename, which is not the same as what you passed to the start method() if a compression method is used.

```php
$settings = array(
    'compress' => Mysqldump::GZIP
);

$dump = new Mysqldump($db, $username, $password, $host, $type, $settings);
$dump->start('dump.sql');
echo $dump->getFilename(); // dump.sql.gz
```