### PR TITLE
Optional parameter to getFilename to guess the archive filename that will be created

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -766,7 +766,7 @@ class CompressBzip2 extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename . ".bz2";
+        $this->archiveFilename = $filename;
         $this->fileHandler = bzopen($this->archiveFilename, "w");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
@@ -802,7 +802,7 @@ class CompressGzip extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename . ".gz";
+        $this->archiveFilename = $filename;
         $this->fileHandler = gzopen($this->archiveFilename, "wb");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -270,16 +270,6 @@ class Mysqldump
     }
 
     /**
-     * Returns written archive filename
-     *
-     * @return string
-     */
-    public function getFilename()
-    {
-        return $this->compressManager->getArchiveFilename();
-    }
-
-    /**
      * Returns header for dump file
      *
      * @return string
@@ -729,8 +719,6 @@ abstract class CompressMethod
 
 abstract class CompressManagerFactory
 {
-    protected $archiveFilename;
-
     /**
      * @param string $c
      * @return CompressBzip2|CompressGzip|CompressNone
@@ -766,8 +754,7 @@ class CompressBzip2 extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename;
-        $this->fileHandler = bzopen($this->archiveFilename, "w");
+        $this->fileHandler = bzopen($filename, "w");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
         }
@@ -802,8 +789,7 @@ class CompressGzip extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename;
-        $this->fileHandler = gzopen($this->archiveFilename, "wb");
+        $this->fileHandler = gzopen($filename, "wb");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
         }

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -734,11 +734,6 @@ abstract class CompressManagerFactory
 
         return new $method;
     }
-
-    public function getArchiveFilename()
-    {
-        return $this->archiveFilename;
-    }
 }
 
 class CompressBzip2 extends CompressManagerFactory
@@ -817,8 +812,7 @@ class CompressNone extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename;
-        $this->fileHandler = fopen($this->archiveFilename, "wb");
+        $this->fileHandler = fopen($filename, "wb");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
         }

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -274,13 +274,9 @@ class Mysqldump
      *
      * @return string
      */
-    public function getFilename($filename = null)
+    public function getFilename()
     {
-        if ($filename === null) {
-            return $this->compressManager->getArchiveFilename();
-        } else {
-            return $filename . CompressMethod::getFileExtension($this->dumpSettings['compress']);
-        }
+        return $this->compressManager->getArchiveFilename();
     }
 
     /**
@@ -716,9 +712,9 @@ class Mysqldump
 abstract class CompressMethod
 {
     public static $enums = array(
-        "None"  => '',
-        "Gzip"  => '.gz',
-        "Bzip2" => '.bz2'
+        "None",
+        "Gzip",
+        "Bzip2"
     );
 
     /**
@@ -727,22 +723,12 @@ abstract class CompressMethod
      */
     public static function isValid($c)
     {
-        return isset(self::$enums[$c]);
-    }
-
-    /**
-     * @param string $c
-     * @return string
-     */
-    public static function getFileExtension($c)
-    {
-        return isset(self::$enums[$c]) ? self::$enums[$c] : '';
+        return in_array($c, self::$enums);
     }
 }
 
 abstract class CompressManagerFactory
 {
-    protected $archiveExtension = '';
     protected $archiveFilename;
 
     /**
@@ -758,9 +744,7 @@ abstract class CompressManagerFactory
 
         $method =  __NAMESPACE__ . "\\" . "Compress" . $c;
 
-        $instance = new $method;
-        $instance->archiveExtension = CompressMethod::getFileExtension($c);
-        return $instance;
+        return new $method;
     }
 
     public function getArchiveFilename()
@@ -782,7 +766,7 @@ class CompressBzip2 extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename . $this->archiveExtension;
+        $this->archiveFilename = $filename . ".bz2";
         $this->fileHandler = bzopen($this->archiveFilename, "w");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
@@ -818,7 +802,7 @@ class CompressGzip extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename . $this->archiveExtension;
+        $this->archiveFilename = $filename . ".gz";
         $this->fileHandler = gzopen($this->archiveFilename, "wb");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");
@@ -847,7 +831,7 @@ class CompressNone extends CompressManagerFactory
 
     public function open($filename)
     {
-        $this->archiveFilename = $filename . $this->archiveExtension;
+        $this->archiveFilename = $filename;
         $this->fileHandler = fopen($this->archiveFilename, "wb");
         if (false === $this->fileHandler) {
             throw new Exception("Output file is not writable");


### PR DESCRIPTION
This modification allows getFilename() to be called before the start() method. This can be useful to control if the dump has already been written, and don't overwrite it (ie: in case of a daily dump that should be done only once)

```php
$settings = array(
    'compress' => Mysqldump::GZIP
);

$output = 'dump.sql';
$dump = new Mysqldump($db, $username, $password, $host, $type, $settings);
if (!is_file($dump->getFilename($output)) { // test if dump.sql.gz already exists, to don't write it twice
    $dump->start($output); // write dump.sql.gz
}
```