### PR TITLE
Implement net_buffer_length functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Refer to the [wiki](https://github.com/ifsnop/mysqldump-php/wiki/full-example) f
   - http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_comments
 - **skip-dump-date**
   - http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_dump-date
+- **net_buffer_length**
+  - http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_net_buffer_length
 
 The following options are now enabled by default, and there is no way to disable them since
 they should always be used.

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -138,6 +138,7 @@ class Mysqldump
             'skip-comments' => false,
             'skip-dump-date' => false,
             'init_commands' => array(),
+            'net_buffer_length' => self::MAXLINESIZE,
             /* deprecated */
             'disable-foreign-keys-check' => true
         );
@@ -840,7 +841,7 @@ class Mysqldump
             } else {
                 $lineSize += $this->compressManager->write(",(" . implode(",", $vals) . ")");
             }
-            if (($lineSize > self::MAXLINESIZE) ||
+            if (($lineSize > $this->dumpSettings['net_buffer_length']) ||
                     !$this->dumpSettings['extended-insert']) {
                 $onlyOnce = true;
                 $lineSize = $this->compressManager->write(";" . PHP_EOL);


### PR DESCRIPTION
Check `dumpSettings['net_buffer_length']` instead of `self::MAXLINESIZE` to determine when to create a new insert

Mimics behaviour of the mysqldump --net_buffer_length argument: http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_net_buffer_length