### PR TITLE
Minor change for virtual column detection

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1860,8 +1860,9 @@ class TypeAdapterMysql extends TypeAdapterFactory
         }
         $colInfo['is_numeric'] = in_array($colInfo['type'], $this->mysqlTypes['numerical']);
         $colInfo['is_blob'] = in_array($colInfo['type'], $this->mysqlTypes['blob']);
-        // for virtual 'Extra' -> "STORED GENERATED"
-        $colInfo['is_virtual'] = strpos($colType['Extra'], "STORED GENERATED") === false ? false : true;
+        // for virtual 'Extra' -> "GENERATED"
+        // MySQL reference: https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html
+        $colInfo['is_virtual'] = strpos($colType['Extra'], "GENERATED") === false ? false : true;
 
         return $colInfo;
     }


### PR DESCRIPTION
Hey there!

First of all, great library! Solved a serious problem with it! Thanks!

Second, we had to make a little change and wonder if it's intentional or not [at this line](https://github.com/ifsnop/mysqldump-php/blob/master/src/Ifsnop/Mysqldump/Mysqldump.php#L1864)
it's looking for the "STORED GENERATED" string but the [syntax definition](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html) is not matching. We applied this patch in local and using like this for months now. 

Hope it makes sense.