### PR TITLE
Fix column names in insert statements generated by the dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.phar
 /.settings
 /vendor/
+/.idea/

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -862,6 +862,7 @@ class Mysqldump
         $lineSize = 0;
 
         $colStmt = $this->getColumnStmt($tableName);
+        $colNames = $this->getColumnNames($tableName);
         $stmt = "SELECT " . implode(",", $colStmt) . " FROM `$tableName`";
 
         if ($this->dumpSettings['where']) {
@@ -877,7 +878,7 @@ class Mysqldump
                 if ($this->dumpSettings['complete-insert']) {
                     $lineSize += $this->compressManager->write(
                         "INSERT INTO `$tableName` (" .
-                        implode(", ", $colStmt) .
+                        implode(", ", $colNames) .
                         ") VALUES (" . implode(",", $vals) . ")"
                     );
                 } else {
@@ -994,7 +995,7 @@ class Mysqldump
     }
 
     /**
-     * Build SQL List of all columns on current table
+     * Build SQL List of all columns on current table which will be used for selecting
      *
      * @param string $tableName  Name of table to get columns
      *
@@ -1017,6 +1018,23 @@ class Mysqldump
         }
 
         return $colStmt;
+    }
+
+    /**
+     * Build SQL List of all columns on current table which will be used for inserting
+     *
+     * @param string $tableName  Name of table to get columns
+     *
+     * @return string SQL sentence with columns
+     */
+    function getColumnNames($tableName)
+    {
+        $colNames = array();
+        foreach($this->tableColumnTypes[$tableName] as $colName => $colType) {
+            $colNames[] = "`${colName}`";
+        }
+
+        return $colNames;
     }
 }
 


### PR DESCRIPTION
Mysqldump has an option of dumping complete insert statements onto the dump file if 'complete-insert' option is set to 'true'. However, if 'hex-blob' is also set to 'true'  the generated column names in insert statement is not correct for binary, bit or blob column types. This commit fixes that issue and generates proper column names.

### Example of original dump
`INSERT INTO tablename (HEX(col1) AS col1, col2) ...`

### Example of dump after the fix
`INSERT INTO tablename (col1, col2) ...`