### PR TITLE
Added tableColumnTypes() getter, fixes #136

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -193,6 +193,16 @@ class Mysqldump
     }
 
     /**
+     * Get table column types.
+     *
+     * @return array
+     */
+    protected function tableColumnTypes()
+    {
+      return $this->tableColumnTypes;
+    }
+
+    /**
      * Custom array_replace_recursive to be used if PHP < 5.3
      * Replaces elements from passed arrays into the first array recursively
      *


### PR DESCRIPTION
I named the function tableColumnTypes equal to the property (which is perfectly legal in php), because getTableColumnTypes is already taken. (There are a bunch of getFoo methods that are not getters and i'd rather call them makeFoo, but that would be a different refactoring.)