### PR TITLE
Add hook to allow derived classes to modify column value output

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -823,21 +823,22 @@ class Mysqldump
      * Prepare values for output
      *
      * @param string $tableName Name of table which contains rows
-     * @param array $row Associative array of column names and values to be quoted
+     * @param array $row Associative array of column names and values to be
+     *   quoted
      *
      * @return array
      */
-   private function prepareColumnValues($tableName, $row)
-   {
-       $ret = [];
-       $columnTypes = $this->tableColumnTypes[$tableName];
-       foreach ($row as $colName => $colValue) {
-           $colValue = $this->hookTransformColumnValue($tableName, $colName, $colValue);
-           $ret[] = $this->escape($colValue, $columnTypes[$colName]);
-       }
+    private function prepareColumnValues($tableName, $row)
+    {
+        $ret = [];
+        $columnTypes = $this->tableColumnTypes[$tableName];
+        foreach ($row as $colName => $colValue) {
+            $colValue = $this->hookTransformColumnValue($tableName, $colName, $colValue);
+            $ret[] = $this->escape($colValue, $columnTypes[$colName]);
+        }
 
-       return $ret;
-   }
+        return $ret;
+    }
 
     /**
      * Escape values with quotes when needed

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -875,7 +875,7 @@ class Mysqldump
      * @return string
      *
      */
-    protected function hookTransformColumnValue($tablename, $colName, $colValue)
+    protected function hookTransformColumnValue($tableName, $colName, $colValue)
     {
       return $colValue;
     }

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -827,14 +827,15 @@ class Mysqldump
      *
      * @return array
      */
-   private function prepareFieldValues($tableName, $row)
+   private function prepareColumnValues($tableName, $row)
    {
-       $ret = array();
+       $ret = [];
        $columnTypes = $this->tableColumnTypes[$tableName];
        foreach ($row as $colName => $colValue) {
            $colValue = $this->hookTransformColumnValue($tableName, $colName, $colValue);
            $ret[] = $this->escape($colValue, $columnTypes[$colName]);
        }
+
        return $ret;
    }
 
@@ -858,13 +859,13 @@ class Mysqldump
             }
         } elseif ($colType['is_numeric']) {
             return $colValue;
-        } else {
-            return $this->dbHandler->quote($colValue);
         }
+
+        return $this->dbHandler->quote($colValue);
     }
 
     /**
-     * Give extending classes an opportunity to transform field values
+     * Give extending classes an opportunity to transform column values
      * 
      * @param string $tableName Name of table which contains rows
      * @param string $colName Name of the column in question
@@ -902,7 +903,7 @@ class Mysqldump
         $resultSet->setFetchMode(PDO::FETCH_ASSOC);
 
         foreach ($resultSet as $row) {
-            $vals = $this->prepareFieldValues($tableName, $row);
+            $vals = $this->prepareColumnValues($tableName, $row);
             if ($onlyOnce || !$this->dumpSettings['extended-insert']) {
 
                 if ($this->dumpSettings['complete-insert']) {

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -820,6 +820,25 @@ class Mysqldump
     }
 
     /**
+     * Prepare values for output
+     *
+     * @param string $tableName Name of table which contains rows
+     * @param array $row Associative array of column names and values to be quoted
+     *
+     * @return array
+     */
+   private function prepareFieldValues($tableName, $row)
+   {
+       $ret = array();
+       $columnTypes = $this->tableColumnTypes[$tableName];
+       foreach ($row as $colName => $colValue) {
+           $colValue = $this->hookTransformColumnValue($tableName, $colName, $colValue);
+           $ret[] = $this->escape($colValue, $columnTypes[$colName]);
+       }
+       return $ret;
+   }
+
+    /**
      * Escape values with quotes when needed
      *
      * @param string $tableName Name of table which contains rows
@@ -827,31 +846,25 @@ class Mysqldump
      *
      * @return string
      */
-    private function escape($tableName, $row)
+    private function escape($colValue, $colType)
     {
-        $ret = array();
-        $columnTypes = $this->tableColumnTypes[$tableName];
-        foreach ($row as $colName => $colValue) {
-            $colValue = $this->transformValuesBeforeEscaping($tableName, $colName, $colValue);
-            if (is_null($colValue)) {
-                $ret[] = "NULL";
-            } elseif ($this->dumpSettings['hex-blob'] && $columnTypes[$colName]['is_blob']) {
-                if ($columnTypes[$colName]['type'] == 'bit' || !empty($colValue)) {
-                    $ret[] = "0x${colValue}";
-                } else {
-                    $ret[] = "''";
-                }
-            } elseif ($columnTypes[$colName]['is_numeric']) {
-                $ret[] = $colValue;
+        if (is_null($colValue)) {
+            return "NULL";
+        } elseif ($this->dumpSettings['hex-blob'] && $colType['is_blob']) {
+            if ($colType['type'] == 'bit' || !empty($colValue)) {
+                return "0x${colValue}";
             } else {
-                $ret[] = $this->dbHandler->quote($colValue);
+                return "''";
             }
+        } elseif ($colType['is_numeric']) {
+            return $colValue;
+        } else {
+            return $this->dbHandler->quote($colValue);
         }
-        return $ret;
     }
 
     /**
-     * Give extending classes an opportunity to transform the output before dumping to file
+     * Give extending classes an opportunity to transform field values
      * 
      * @param string $tableName Name of table which contains rows
      * @param string $colName Name of the column in question
@@ -860,7 +873,7 @@ class Mysqldump
      * @return string
      *
      */
-    protected function transformValuesBeforeEscaping($tablename, $colName, $colValue)
+    protected function hookTransformColumnValue($tablename, $colName, $colValue)
     {
       return $colValue;
     }
@@ -889,7 +902,7 @@ class Mysqldump
         $resultSet->setFetchMode(PDO::FETCH_ASSOC);
 
         foreach ($resultSet as $row) {
-            $vals = $this->escape($tableName, $row);
+            $vals = $this->prepareFieldValues($tableName, $row);
             if ($onlyOnce || !$this->dumpSettings['extended-insert']) {
 
                 if ($this->dumpSettings['complete-insert']) {

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -832,6 +832,7 @@ class Mysqldump
         $ret = array();
         $columnTypes = $this->tableColumnTypes[$tableName];
         foreach ($row as $colName => $colValue) {
+            $colValue = $this->transformValuesBeforeEscaping($tableName, $colName, $colValue);
             if (is_null($colValue)) {
                 $ret[] = "NULL";
             } elseif ($this->dumpSettings['hex-blob'] && $columnTypes[$colName]['is_blob']) {
@@ -847,6 +848,21 @@ class Mysqldump
             }
         }
         return $ret;
+    }
+
+    /**
+     * Give extending classes an opportunity to transform the output before dumping to file
+     * 
+     * @param string $tableName Name of table which contains rows
+     * @param string $colName Name of the column in question
+     * @param string $colValue Value of the column in question
+     * 
+     * @return string
+     *
+     */
+    protected function transformValuesBeforeEscaping($tablename, $colName, $colValue)
+    {
+      return $colValue;
     }
 
     /**


### PR DESCRIPTION
This addresses #101 

Essentially, what I did was take the iteration that was being done in the "escape" method and move it into its own "driver" method. The "escape" method changes slightly to _simply_ escape individual values (rather than doing the iteration), and the hook is introduced as step 1 of the driver function (namely, "prepareColumnValues()");

The hook itself is then called hookTransformColumnValue() - it's protected and can be overridden by child classes.