### PR TITLE
Allow setting a transform column value callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ Plain old PHP:
 
 Refer to the [wiki](https://github.com/ifsnop/mysqldump-php/wiki/full-example) for some examples and a comparision between mysqldump and mysqldump-php dumps.
 
+## Changing values when exporting
+You can register a callable that will be used to transform values during the export. An example use-case for this is removing sensitive data from database dumps:
+
+```php
+$dumper = new IMysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
+
+$dumper->setTransformColumnValueHook(function ($tableName, $colName, $colValue) {
+    if ($colName === 'social_security_number') {
+        return (string) rand(1000000, 9999999);
+    }
+    
+    return $colValue;
+});
+
+$dumper->start('storage/work/dump.sql');
+```
+
 ## Constructor and default parameters
 ```php
 /**


### PR DESCRIPTION
This PR adds the functionality to set a callable that will be used as the hook to transform column values. This was first proposed in #144. The main advantage of this is that you don't have to extend the Mysqldump class to register a hook.

With this PR you can register any callable to transform the column values:
```php
$dumper = new IMysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');

$dumper->setTransformColumnValueHook(function ($tableName, $colName, $colValue) {
    return strtoupper($colValue);
});

$dumper->start('storage/work/dump.sql');
```

The `hookTransformColumnValue()` method signature was not changed, that means this change is backwards compatible. This PR won't break applications that were already registering the hook by extending the class.