### PR TITLE
Add support for accessing row data in the hook

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -884,7 +884,7 @@ class Mysqldump
         $ret = [];
         $columnTypes = $this->tableColumnTypes[$tableName];
         foreach ($row as $colName => $colValue) {
-            $colValue = $this->hookTransformColumnValue($tableName, $colName, $colValue);
+            $colValue = $this->hookTransformColumnValue($tableName, $colName, $colValue, $row);
             $ret[] = $this->escape($colValue, $columnTypes[$colName]);
         }
 
@@ -937,7 +937,7 @@ class Mysqldump
      *
      * @return string
      */
-    protected function hookTransformColumnValue($tableName, $colName, $colValue)
+    protected function hookTransformColumnValue($tableName, $colName, $colValue, $row)
     {
         if (! $this->transformColumnValueCallable) {
             return $colValue;
@@ -947,6 +947,7 @@ class Mysqldump
             $tableName,
             $colName,
             $colValue,
+            $row
         ));
     }
 


### PR DESCRIPTION
This ability is nessessary if you need to add a row-based condition for modifying data on-the-fly or use other column values for calculating the hook result.