### PR TITLE
[README.md] Let Composer choose the right version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,8 @@ From version 2.0, connections to database are made using the standard DSN, docum
 Using [Composer](https://getcomposer.org/):
 
 ```
-$ composer require ifsnop/mysqldump-php:2.*
+$ composer require ifsnop/mysqldump-php
 
-```
-
-Or via json file:
-
-```
-"require": {
-        "ifsnop/mysqldump-php":"2.*"
-}
 ```
 
 Using [Curl](https://curl.haxx.se/) to always download and decompress the latest release:


### PR DESCRIPTION
Composer already choose the appropriate version and constraint, base on the latest release:

```
$ composer require ifsnop/mysqldump-php
Using version ^2.5 for ifsnop/mysqldump-php
./composer.json has been created
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing ifsnop/mysqldump-php (v2.5): Downloading (100%)         
Writing lock file
Generating autoload files

$ cat composer.json 
{
    "require": {
        "ifsnop/mysqldump-php": "^2.5"
    }
}

```