### PR TITLE
Add ability to add table specific 'where' conditions and 'LIMITs'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -44,6 +45,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -69,6 +71,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -94,6 +97,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -119,6 +123,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -144,6 +149,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -169,6 +175,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -194,6 +201,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -219,6 +227,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -244,6 +253,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     addons:
       apt:
        sources:
@@ -270,6 +280,7 @@ matrix:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
       - cd tests && ./test.sh
+      - vendor/bin/phpunit
     before_install:
       - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -44,8 +44,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -70,8 +70,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -96,8 +96,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -122,8 +122,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -148,8 +148,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -174,8 +174,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -200,8 +200,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -226,8 +226,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -252,8 +252,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     addons:
       apt:
        sources:
@@ -279,8 +279,8 @@ matrix:
     script:
       - php -l src/Ifsnop/Mysqldump/Mysqldump.php
       - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - cd tests && ./test.sh
       - vendor/bin/phpunit
+      - cd tests && ./test.sh
     before_install:
       - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ $dumper->setTransformColumnValueHook(function ($tableName, $colName, $colValue) 
 $dumper->start('storage/work/dump.sql');
 ```
 
+## Table specific export conditions
+You can register table specific 'where' clauses to limit data on a per table basis.  These override the default `where` dump setting:
+
+```php
+$dumper = new IMysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
+
+$dumper->setTableWheres(array(
+    'users' => 'date_registered > NOW() - INTERVAL 3 MONTH AND deleted=0',
+    'logs' => 'date_logged > NOW() - INTERVAL 1 DAY',
+    'posts' => 'isLive=1'
+));
+```
+
 ## Constructor and default parameters
 ```php
 /**

--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ $dumper->setTableWheres(array(
 ));
 ```
 
+## Table specific export limits
+You can register table specific 'limits' to limit the returned rows on a per table basis:
+
+```php
+$dumper = new IMysqldump\Mysqldump('mysql:host=localhost;dbname=testdb', 'username', 'password');
+
+$dumper->setTableLimits(array(
+    'users' => 300,
+    'logs' => 50,
+    'posts' => 10
+));
+```
+
 ## Constructor and default parameters
 ```php
 /**

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "1.*"
+        "squizlabs/php_codesniffer": "1.*",
+        "phpunit/phpunit": "4.8.36"
     },
     "autoload": {
         "psr-4": {"Ifsnop\\": "src/Ifsnop/"}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         colors="true"
+         verbose="true">
+    <testsuite name="default">
+        <directory suffix="Test.php">unit-tests</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -105,6 +105,7 @@ class Mysqldump
      * @var array
      */
     private $tableWheres = array();
+    private $tableLimits = array();
 
     /**
      * Constructor of Mysqldump. Note that in the case of an SQLite database
@@ -256,6 +257,36 @@ class Mysqldump
         }
 
         return false;
+    }
+
+    /**
+     * Keyed by table name, with the value as the numeric limit:
+     * e.g. 'users' => 3000
+     *
+     * @param array $tableLimits
+     */
+    public function setTableLimits(array $tableLimits)
+    {
+        $this->tableLimits = $tableLimits;
+    }
+
+    /**
+     * Returns the LIMIT for the table.  Must be numeric to be returned.
+     * @param $tableName
+     * @return bool
+     */
+    public function getTableLimit($tableName)
+    {
+        if (empty($this->tableLimits[$tableName])) {
+            return false;
+        }
+
+        $limit = $this->tableLimits[$tableName];
+        if (!is_numeric($limit)) {
+            return false;
+        }
+
+        return $limit;
     }
 
     /**
@@ -1017,6 +1048,12 @@ class Mysqldump
 
         if ($condition) {
             $stmt .= " WHERE {$condition}";
+        }
+
+        $limit = $this->getTableLimit($tableName);
+
+        if ($limit) {
+            $stmt .= " LIMIT {$limit}";
         }
 
         $resultSet = $this->dbHandler->query($stmt);

--- a/unit-tests/MysqldumpTest.php
+++ b/unit-tests/MysqldumpTest.php
@@ -28,4 +28,21 @@ class MysqldumpTest extends PHPUnit_Framework_TestCase
             $dump->getTableWhere('non_overriden_table')
         );
     }
+
+    /** @test */
+    public function tableSpecificLimitsWork()
+    {
+        $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'testing', 'testing');
+
+        $dump->setTableLimits(array(
+            'users' => 200,
+            'logs' => 500,
+            'table_with_invalid_limit' => '41923, 42992'
+        ));
+
+        $this->assertEquals(200, $dump->getTableLimit('users'));
+        $this->assertEquals(500, $dump->getTableLimit('logs'));
+        $this->assertFalse($dump->getTableLimit('table_with_invalid_limit'));
+        $this->assertFalse($dump->getTableLimit('table_name_with_no_limit'));
+    }
 }

--- a/unit-tests/MysqldumpTest.php
+++ b/unit-tests/MysqldumpTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Ifsnop\Mysqldump\Mysqldump;
+
+class MysqldumpTest extends PHPUnit_Framework_TestCase
+{
+
+    /** @test */
+    public function tableSpecificWhereConditionsWork()
+    {
+        $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'testing', 'testing', array(
+            'where' => 'defaultWhere'
+        ));
+
+        $dump->setTableWheres(array(
+            'users' => 'date_registered > NOW() - INTERVAL 3 MONTH AND is_deleted=0',
+            'logs' => 'date_registered > NOW() - INTERVAL 1 DAY',
+            'posts' => 'active=1'
+        ));
+
+        $this->assertEquals(
+            'date_registered > NOW() - INTERVAL 3 MONTH AND is_deleted=0',
+            $dump->getTableWhere('users')
+        );
+
+        $this->assertEquals(
+            'defaultWhere',
+            $dump->getTableWhere('non_overriden_table')
+        );
+    }
+}


### PR DESCRIPTION
Refs: https://github.com/ifsnop/mysqldump-php/issues/118 

# Why
This MR is to add the ability to add table specific 'where' conditions and 'LIMITs'.  With this users can limit the data they want to output, on a more specific basis such as limiting `posts` to only active ones, or `users` to 30 recently logged in ones.

This is especially useful when dumping data to use on staging/development, to restrict the data in use.  Or for debugging purposes, should production data be required for testing.

# Acceptance Criteria
* [ ] Tests still work
* [ ] Unit tests work (`vendor/bin/phpunit`)
* [ ] Table specific where conditions override the default dumpOptions 'where'
* [ ] Table specific `LIMIT`s add `LIMIT` to dump queries

# How I tested

* `vendor/bin/phpunit` to ensure unit tests pass
* Created local database with tables and data, ran `mysqldump-php` passing tableSpecific conditions and limits

# Thoughts/notes
* This is backwards compatible
* I wondered about the method names, and feel like `conditions` would be better (`setTableConditions` or `setTableWhereConditions`) but tried to stick with the `where` that's already there