### PR TITLE
Fixed mysql function export order issue

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -450,9 +450,9 @@ class Mysqldump
 
         $this->exportTables();
         $this->exportTriggers();
+        $this->exportFunctions();
         $this->exportViews();
         $this->exportProcedures();
-        $this->exportFunctions();
         $this->exportEvents();
 
         // Restore saved parameters.


### PR DESCRIPTION
Mysql functions need to be exported before views to ensure they exist during the time of view creation.