### PR TITLE
Add test files to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 /tests export-ignore
+/unit-tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
Unnecessary `unit-tests/` and `phpunit.xml` were still installed with `composer`.