### PR TITLE
Allow to select the empty set 'limit 0'

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -287,7 +287,7 @@ class Mysqldump
      */
     public function getTableLimit($tableName)
     {
-        if (empty($this->tableLimits[$tableName])) {
+        if (!isset($this->tableLimits[$tableName])) {
             return false;
         }
 
@@ -1133,7 +1133,7 @@ class Mysqldump
 
         $limit = $this->getTableLimit($tableName);
 
-        if ($limit) {
+        if ($limit !== false) {
             $stmt .= " LIMIT {$limit}";
         }
 


### PR DESCRIPTION
Hi,

Mysql allows you to limit by 0, which returns the empty set. This is useful for when you want to dump the table but without records, for example the customers table of a production database. You want to have the table but not the customers since that would be a GDPR violation. 

I've noticed that this package doesn't support setting the table limit as 0 and therefore it doesn't support the use case of dumping a table but ignoring all the data inside. 