### PR TITLE
Add support for "if-not-exists" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ $dumpSettingsDefault = array(
     'compress' => Mysqldump::NONE,
     'init_commands' => array(),
     'no-data' => array(),
+    'if-not-exists' => false,
     'reset-auto-increment' => false,
     'add-drop-database' => false,
     'add-drop-table' => false,
@@ -220,6 +221,8 @@ $this->_dumpSettings = self::array_replace_recursive($dumpSettingsDefault, $dump
   - Exclude these tables (array of table names), include all if empty, supports regexps.
 - **include-views**
   - Only include these views (array of view names), include all if empty. By default, all views named as the include-tables array are included.
+- **if-not-exists**
+  - Only create a new table when a table of the same name does not already exist. No error message is thrown if the table already exists. 
 - **compress**
   - Gzip, Bzip2, None.
   - Could be specified using the declared consts: IMysqldump\Mysqldump::GZIP, IMysqldump\Mysqldump::BZIP2 or IMysqldump\Mysqldump::NONE

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1876,7 +1876,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         }
         
 		if ($this->dumpSettings['if-not-exists'] ) {
-			$createTable = preg_replace('/CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $createTable, 1);
+			$createTable = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $createTable);
         }        
 
         $ret = "/*!40101 SET @saved_cs_client     = @@character_set_client */;".PHP_EOL.


### PR DESCRIPTION
It would be quite useful if there was an option like 'if-not-exists' that would append “IF NOT EXISTS” to "CREATE TABLE" ("CREATE TABLE IF NOT EXISTS") to avoid errors when a table already exists.

Details here: https://github.com/ifsnop/mysqldump-php/issues/203