### PR TITLE
add binary constant

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -43,7 +43,8 @@ class Mysqldump
     // List of available connection strings.
     const UTF8    = 'utf8';
     const UTF8MB4 = 'utf8mb4';
-
+    const BINARY = 'binary';
+    
     /**
      * Database username.
      * @var string


### PR DESCRIPTION
Add binary constant as possible choice for default-character-set.

The reason I propose this is because I do a lot of database migrations and often there are old databases I need to migrate to another server. Those databases have now outdated latin1 charset. From my experience, the best way to avoid any problems while migrating is:

1. Dump data in binary with default-character-set set as 'binary'
2. Open the dump in text editor. Change all charset from latin1 to UTF8.
3. Upload the dump to another server in binary charset as well.

This prevents problems with broken characters.
