### PR TITLE
virtual cols: fix unwanted insert on bit+hex-blob

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1266,13 +1266,13 @@ class Mysqldump
     {
         $colStmt = array();
         foreach ($this->tableColumnTypes[$tableName] as $colName => $colType) {
-            if ($colType['type'] == 'bit' && $this->dumpSettings['hex-blob']) {
+            if ($colType['is_virtual']) {
+                $this->dumpSettings['complete-insert'] = true;
+                continue;
+            } elseif ($colType['type'] == 'bit' && $this->dumpSettings['hex-blob']) {
                 $colStmt[] = "LPAD(HEX(`${colName}`),2,'0') AS `${colName}`";
             } elseif ($colType['is_blob'] && $this->dumpSettings['hex-blob']) {
                 $colStmt[] = "HEX(`${colName}`) AS `${colName}`";
-            } elseif ($colType['is_virtual']) {
-                $this->dumpSettings['complete-insert'] = true;
-                continue;
             } else {
                 $colStmt[] = "`${colName}`";
             }


### PR DESCRIPTION
When hex-blob was specified and virtual columns of type  blob or bit existed, produced dump file was invalid.

Move the "virtual-column" case on the top of the getColumnStmt process to totally ignore generated columns & switch to complete insert even if hex-blob is specified and we've a bit generated column.