### PR TITLE
Add support for MariaDB System-Versioned Tables

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -2069,7 +2069,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $args = func_get_args();
         return "SELECT TABLE_NAME AS tbl_name ".
             "FROM INFORMATION_SCHEMA.TABLES ".
-            "WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA='${args[0]}'";
+            "WHERE TABLE_TYPE IN ('BASE TABLE', 'SYSTEM VERSIONED') AND TABLE_SCHEMA='${args[0]}'";
     }
 
     public function show_views()


### PR DESCRIPTION
Thanks for the great library.

Exports of [MariaDB's System-Versioned Tables](https://mariadb.com/kb/en/system-versioned-tables/) fail at the moment, but this little fix resolves it.