### PR TITLE
Allow for trailing semicolon on connect string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.settings
 # Vim swap files
 .*.sw*
+.phpunit.result.cache
 
 /composer.lock
 /composer.phar

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -44,7 +44,7 @@ class Mysqldump
     const UTF8    = 'utf8';
     const UTF8MB4 = 'utf8mb4';
     const BINARY = 'binary';
-    
+
     /**
      * Database username.
      * @var string
@@ -301,9 +301,11 @@ class Mysqldump
 
         $dsn = substr($dsn, $pos + 1);
 
-        foreach (explode(";", $dsn) as $kvp) {
-            $kvpArr = explode("=", $kvp);
-            $this->dsnArray[strtolower($kvpArr[0])] = $kvpArr[1];
+        foreach (explode(';', $dsn) as $kvp) {
+            if (strpos($kvp, '=') !== false) {
+                $kvpArr = explode('=', $kvp);
+                $this->dsnArray[strtolower($kvpArr[0])] = $kvpArr[1];
+            }
         }
 
         if (empty($this->dsnArray['host']) &&
@@ -1875,10 +1877,10 @@ class TypeAdapterMysql extends TypeAdapterFactory
             $replace = "";
             $createTable = preg_replace($match, $replace, $createTable);
         }
-        
+
 		if ($this->dumpSettings['if-not-exists'] ) {
 			$createTable = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $createTable);
-        }        
+        }
 
         $ret = "/*!40101 SET @saved_cs_client     = @@character_set_client */;".PHP_EOL.
             "/*!40101 SET character_set_client = ".$this->dumpSettings['default-character-set']." */;".PHP_EOL.

--- a/tests/test.php
+++ b/tests/test.php
@@ -62,7 +62,7 @@ print "starting mysql-php_test002.sql" . PHP_EOL;
 $dumpSettings['default-character-set'] = IMysqldump\Mysqldump::UTF8MB4;
 $dumpSettings['complete-insert'] = true;
 $dump = new IMysqldump\Mysqldump(
-    "mysql:host=localhost;dbname=test002",
+    "mysql:host=localhost;dbname=test002;",
     "travis",
     "",
     $dumpSettings);
@@ -87,7 +87,7 @@ $dump->start("mysqldump-php_test006.sql");
 
 print "starting mysql-php_test008.sql" . PHP_EOL;
 $dump = new IMysqldump\Mysqldump(
-    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test008",
+    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test008;",
     "travis",
     "",
     array("no-data" => true, "add-drop-table" => true));
@@ -95,7 +95,7 @@ $dump->start("mysqldump-php_test008.sql");
 
 print "starting mysql-php_test009.sql" . PHP_EOL;
 $dump = new IMysqldump\Mysqldump(
-    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test009",
+    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test009;",
     "travis",
     "",
     array("no-data" => true, "add-drop-table" => true, "reset-auto-increment" => true, "add-drop-database" => true));
@@ -103,7 +103,7 @@ $dump->start("mysqldump-php_test009.sql");
 
 print "starting mysql-php_test010.sql" . PHP_EOL;
 $dump = new IMysqldump\Mysqldump(
-    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test010",
+    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test010;",
     "travis",
     "",
     array("events" => true));
@@ -119,7 +119,7 @@ $dump->start("mysqldump-php_test011a.sql");
 
 print "starting mysql-php_test011b.sql" . PHP_EOL;
 $dump = new IMysqldump\Mysqldump(
-    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test011",
+    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test011;",
     "travis",
     "",
     array('complete-insert' =>  true));
@@ -127,7 +127,7 @@ $dump->start("mysqldump-php_test011b.sql");
 
 print "starting mysql-php_test012.sql" . PHP_EOL;
 $dump = new IMysqldump\Mysqldump(
-    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test012",
+    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test012;",
     "travis",
     "",
     array("events" => true,
@@ -153,7 +153,7 @@ $dump->start("mysqldump-php_test012_no-definer.sql");
 
 print "starting mysql-php_test013.sql" . PHP_EOL;
 $dump = new IMysqldump\Mysqldump(
-    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test001",
+    "mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=test001;",
     "travis",
     "",
     array(

--- a/unit-tests/MysqldumpTest.php
+++ b/unit-tests/MysqldumpTest.php
@@ -32,7 +32,7 @@ class MysqldumpTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function tableSpecificLimitsWork()
     {
-        $dump = new Mysqldump('mysql:host=localhost;dbname=test', 'testing', 'testing');
+        $dump = new Mysqldump('mysql:host=localhost;dbname=test;', 'testing', 'testing');
 
         $dump->setTableLimits(array(
             'users' => 200,


### PR DESCRIPTION
A trailing semicolon is legal in PDO, but the library currently bombs is it is supplied. This PR allows for trailing (and sequential) semicolons in the connect string.

- Could not run tests, as I only support PHP 7.1 and higher, but tests should run.
- Added to .gitignore for future versions of PHPUnit
- Added trailing semicolons in tests  at semi random places, including identical connect strings, one with, and one without the semicolon.
- Removed some trailing white space.