### PR TITLE
Order table names for MariaDB-to-MySQL compatibility

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -2069,7 +2069,8 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $args = func_get_args();
         return "SELECT TABLE_NAME AS tbl_name ".
             "FROM INFORMATION_SCHEMA.TABLES ".
-            "WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA='${args[0]}'";
+            "WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA='${args[0]}' ".
+            "ORDER BY TABLE_NAME";
     }
 
     public function show_views()
@@ -2078,7 +2079,8 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $args = func_get_args();
         return "SELECT TABLE_NAME AS tbl_name ".
             "FROM INFORMATION_SCHEMA.TABLES ".
-            "WHERE TABLE_TYPE='VIEW' AND TABLE_SCHEMA='${args[0]}'";
+            "WHERE TABLE_TYPE='VIEW' AND TABLE_SCHEMA='${args[0]}' ".
+            "ORDER BY TABLE_NAME";
     }
 
     public function show_triggers()


### PR DESCRIPTION
Hi, unlike MySQL, MariaDB stores table names into `INFORMATION_SCHEMA.TABLES` randomly.
This result in a different output on different systems.

The fix proposed is compatible with both MySQL and MariaDB, all versions included.