### PR TITLE
Add option to disable database creation statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ $this->_dumpSettings = self::array_replace_recursive($dumpSettingsDefault, $dump
 - **include-views**
   - Only include these views (array of view names), include all if empty. By default, all views named as the include-tables array are included.
 - **if-not-exists**
-  - Only create a new table when a table of the same name does not already exist. No error message is thrown if the table already exists. 
+  - Only create a new table when a table of the same name does not already exist. No error message is thrown if the table already exists.
 - **compress**
   - Gzip, Bzip2, None.
   - Could be specified using the declared consts: IMysqldump\Mysqldump::GZIP, IMysqldump\Mysqldump::BZIP2 or IMysqldump\Mysqldump::NONE

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ $dumpSettingsDefault = array(
     'insert-ignore' => false,
     'net_buffer_length' => self::MAXLINESIZE,
     'no-autocommit' => true,
+    'no-create-db' => false,
     'no-create-info' => false,
     'lock-tables' => true,
     'routines' => false,
@@ -263,6 +264,8 @@ $this->_dumpSettings = self::array_replace_recursive($dumpSettingsDefault, $dump
 - **no-autocommit**
   - Option to disable autocommit (faster inserts, no problems with index keys)
   - https://dev.mysql.com/doc/refman/4.1/en/commit.html
+- **no-create-db**
+  - https://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_no-create-db
 - **no-create-info**
   - https://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_no-create-info
 - **no-data**

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -44,7 +44,7 @@ class Mysqldump
     const UTF8    = 'utf8';
     const UTF8MB4 = 'utf8mb4';
     const BINARY = 'binary';
-    
+
     /**
      * Database username.
      * @var string
@@ -1881,10 +1881,10 @@ class TypeAdapterMysql extends TypeAdapterFactory
             $replace = "";
             $createTable = preg_replace($match, $replace, $createTable);
         }
-        
+
 		if ($this->dumpSettings['if-not-exists'] ) {
 			$createTable = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $createTable);
-        }        
+        }
 
         $ret = "/*!40101 SET @saved_cs_client     = @@character_set_client */;".PHP_EOL.
             "/*!40101 SET character_set_client = ".$this->dumpSettings['default-character-set']." */;".PHP_EOL.

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -156,6 +156,7 @@ class Mysqldump
             'insert-ignore' => false,
             'net_buffer_length' => self::MAXLINESIZE,
             'no-autocommit' => true,
+            'no-create-db' => false,
             'no-create-info' => false,
             'lock-tables' => true,
             'routines' => false,
@@ -1812,6 +1813,11 @@ class TypeAdapterMysql extends TypeAdapterFactory
 
     public function databases()
     {
+
+        if ($this->dumpSettings['no-create-db']) {
+            return "";
+        }
+
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
         $databaseName = $args[0];


### PR DESCRIPTION
This PR aims to mimic the mysqldump option [no-create-db](https://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_no-create-db).

This is useful if for example you only want to dump the data but not the schema, without this option it would dump the data but with the `CREATE DATABASE...` and `USE DATABASE` statements, which is undesirable.

I'm sorry I wasn't capabale of adding a test.