### PR TITLE
PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # editors
 /.project
 /.settings
+/.idea
 # Vim swap files
 .*.sw*
 
 /composer.lock
 /composer.phar
 /vendor/
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,150 +2,6 @@ language: php
 
 matrix:
   include:
-  - php: 5.3
-    dist: precise
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
-  - php: 5.4
-    dist: precise
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
-  - php: 5.5
-    dist: precise
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
-  - php: 5.6
-    dist: precise
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
-  - php: 5.6
-    dist: xenial
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
-  - php: 7.0
-    dist: xenial
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
-  - php: 7.1
-    dist: xenial
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
-  - php: 7.2
-    dist: xenial
-    sudo: required
-    services:
-      - mysql
-    before_script:
-      - curl -s http://getcomposer.org/installer | php
-      - php composer.phar install
-      - mysql -V
-      - mysqldump -V
-      - tests/create_users.sh
-    script:
-      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
-      - php src/Ifsnop/Mysqldump/Mysqldump.php
-      - vendor/bin/phpunit
-      - cd tests && ./test.sh
-    before_install:
-      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
   - php: 7.3
     dist: xenial
     sudo: required
@@ -165,6 +21,24 @@ matrix:
     before_install:
       - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
   - php: 7.4
+    dist: xenial
+    sudo: required
+    services:
+      - mysql
+    before_script:
+      - curl -s http://getcomposer.org/installer | php
+      - php composer.phar install
+      - mysql -V
+      - mysqldump -V
+      - tests/create_users.sh
+    script:
+      - php -l src/Ifsnop/Mysqldump/Mysqldump.php
+      - php src/Ifsnop/Mysqldump/Mysqldump.php
+      - vendor/bin/phpunit
+      - cd tests && ./test.sh
+    before_install:
+      - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
+  - php: 8.0
     dist: xenial
     sudo: required
     services:
@@ -274,6 +148,5 @@ matrix:
       - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
 
   allow_failures:
-    - php: 5.3
     - php: nightly
     - php: hhvm

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Out of the box, MySQLDump-PHP supports backing up table structures, the data its
 MySQLDump-PHP is the only library that supports:
 * output binary blobs as hex.
 * resolves view dependencies (using Stand-In tables).
-* output compared against original mysqldump. Linked to travis-ci testing system (testing from php 5.3 to 7.3 & hhvm)
+* output compared against original mysqldump. Linked to travis-ci testing system (testing from php 7.3 to 8.0 & hhvm)
 * dumps stored routines (functions and procedures).
 * dumps events.
 * does extended-insert and/or complete-insert.
@@ -40,7 +40,7 @@ From version 2.0, connections to database are made using the standard DSN, docum
 
 ## Requirements
 
-- PHP 5.3.0 or newer
+- PHP 7.3.0 or newer
 - MySQL 4.1.0 or newer
 - [PDO](https://secure.php.net/pdo)
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.3.0",
+        "ext-pdo": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "1.*",
-        "phpunit/phpunit": "4.8.36"
+        "phpunit/phpunit": "9.5.7"
     },
     "autoload": {
         "psr-4": {"Ifsnop\\": "src/Ifsnop/"}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          beStrictAboutCoversAnnotation="true"
@@ -13,9 +13,9 @@
         <directory suffix="Test.php">unit-tests</directory>
     </testsuite>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/unit-tests/MysqldumpTest.php
+++ b/unit-tests/MysqldumpTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Ifsnop\Mysqldump\Mysqldump;
+use PHPUnit\Framework\TestCase;
 
-class MysqldumpTest extends PHPUnit_Framework_TestCase
+class MysqldumpTest extends TestCase
 {
 
     /** @test */


### PR DESCRIPTION
- All `<= PHP 7.2` have reached their EoL and are no longer officially supported and there is no even security support. [Source](https://www.php.net/supported-versions.php).
- PHPUnit 9 supports only `>= PHP 7.3`. [Source](https://phpunit.de/supported-versions.html).
- PHPUnit 4 Life support was until February 3, 2017. And it has calling methods that no longer exist in PHP 8. [Source](https://stackoverflow.com/questions/66388326/phpunit-php-fatal-error-uncaught-error-call-to-undefined-function-each).