### PR TITLE
Feature: added ability to append sql that should be run in the end of an import

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -165,6 +165,7 @@ class Mysqldump
             'skip-comments' => false,
             'skip-dump-date' => false,
             'skip-definer' => false,
+			'append_extra_sqls' => false,
             'where' => '',
             /* deprecated */
             'disable-foreign-keys-check' => true
@@ -438,6 +439,15 @@ class Mysqldump
         $this->exportProcedures();
         $this->exportViews();
         $this->exportEvents();
+
+		// extra sqls that should be run
+        if ($this->dumpSettings['append_extra_sqls']) {
+            $this->compressManager->write("-- START EXTRA SQLS".PHP_EOL);
+	        $this->compressManager->write("SET autocommit=0;".PHP_EOL);
+            $this->compressManager->write($this->dumpSettings['append_extra_sqls'].PHP_EOL);
+	        $this->compressManager->write("COMMIT;".PHP_EOL);
+            $this->compressManager->write("-- END EXTRA SQLS".PHP_EOL);
+        }
 
         // Restore saved parameters.
         $this->compressManager->write(


### PR DESCRIPTION
This is relevant when you want to anonymize some of the dumps you do, but in a development enviroment you probably want to auto-set some values in different columns based on types.

From our own example:
We would like to autoset some integration parameters depending on the"module" that is being used. When we have a ton of different modules and multiple entries in a db, this list is typically autogenerated. Using this append sql we are able to do some updates after an import of those values.

Not sure if other people would benefit from this, but i thougt i would like to share our change to the dumper so others could benefit from it.