### PR TITLE
Inline escape() method to improve performance

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1066,40 +1066,32 @@ class Mysqldump
             $row = call_user_func($this->transformTableRowCallable, $tableName, $row);
         }
 
+        $dbHandler = $this->dbHandler;
         foreach ($row as $colName => $colValue) {
             if ($this->transformColumnValueCallable) {
                 $colValue = call_user_func($this->transformColumnValueCallable, $tableName, $colName, $colValue, $row);
             }
+            $colType = $columnTypes[$colName];
 
-            $ret[] = $this->escape($colValue, $columnTypes[$colName]);
+            if ($colValue === null) {
+                $ret[] = "NULL";
+                continue;
+            } elseif ($this->dumpSettings['hex-blob'] && $colType['is_blob']) {
+                if ($colType['type'] == 'bit' || !empty($colValue)) {
+                    $ret[] = "0x{$colValue}";
+                } else {
+                    $ret[] = "''";
+                }
+                continue;
+            } elseif ($colType['is_numeric']) {
+                $ret[] = $colValue;
+                continue;
+            }
+
+            $ret[] = $dbHandler->quote($colValue);
         }
 
         return $ret;
-    }
-
-    /**
-     * Escape values with quotes when needed
-     *
-     * @param string $tableName Name of table which contains rows
-     * @param array $row Associative array of column names and values to be quoted
-     *
-     * @return string
-     */
-    private function escape($colValue, $colType)
-    {
-        if (is_null($colValue)) {
-            return "NULL";
-        } elseif ($this->dumpSettings['hex-blob'] && $colType['is_blob']) {
-            if ($colType['type'] == 'bit' || !empty($colValue)) {
-                return "0x{$colValue}";
-            } else {
-                return "''";
-            }
-        } elseif ($colType['is_numeric']) {
-            return $colValue;
-        }
-
-        return $this->dbHandler->quote($colValue);
     }
 
     /**

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1071,19 +1071,23 @@ class Mysqldump
             if ($this->transformColumnValueCallable) {
                 $colValue = call_user_func($this->transformColumnValueCallable, $tableName, $colName, $colValue, $row);
             }
-            $colType = $columnTypes[$colName];
 
             if ($colValue === null) {
                 $ret[] = "NULL";
                 continue;
-            } elseif ($this->dumpSettings['hex-blob'] && $colType['is_blob']) {
-		if ($colType['type'] == 'bit' || $colValue !== '') {
+            }
+
+            $colType = $columnTypes[$colName];
+            if ($this->dumpSettings['hex-blob'] && $colType['is_blob']) {
+		        if ($colType['type'] == 'bit' || $colValue !== '') {
                     $ret[] = "0x{$colValue}";
                 } else {
                     $ret[] = "''";
                 }
                 continue;
-            } elseif ($colType['is_numeric']) {
+            }
+
+            if ($colType['is_numeric']) {
                 $ret[] = $colValue;
                 continue;
             }

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1077,7 +1077,7 @@ class Mysqldump
                 $ret[] = "NULL";
                 continue;
             } elseif ($this->dumpSettings['hex-blob'] && $colType['is_blob']) {
-                if ($colType['type'] == 'bit' || !empty($colValue)) {
+		if ($colType['type'] == 'bit' || $colValue !== '') {
                     $ret[] = "0x{$colValue}";
                 } else {
                     $ret[] = "''";


### PR DESCRIPTION
dumping a InnoDB table containing  1,4 GiB  of data ...

```php
<?php // test.php

error_reporting(E_ALL);

require_once __DIR__ . '/vendor/autoload.php';

use Ifsnop\Mysqldump as IMysqldump;

$date = date('Ymd');
$dumpSettings = array(
    'compress' => IMysqldump\Mysqldump::NONE,
    'no-data' => false,
    'add-drop-table' => true,
    'single-transaction' => true,
    'lock-tables' => false,
    'add-locks' => true,
    'extended-insert' => true,
    'disable-foreign-keys-check' => true,
    'skip-triggers' => false,
    'add-drop-trigger' => true,
    'databases' => true,
    'add-drop-database' => true,
    'hex-blob' => true,
    'include-tables' => array('my-table'), // add a table name here
);

$dump = new IMysqldump\Mysqldump("mysql:host=$hostname;dbname=$db", $username, $password, $dumpSettings); // add DB credentials
$dump->start("backup$date.sql");
```


before this change
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m41.353s
user    0m30.015s
sys     0m7.903s
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m43.333s
user    0m31.603s
sys     0m8.279s
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php
```

after this change
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m37.625s
user    0m26.760s
sys     0m7.848s

mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test.php

real    0m37.937s
user    0m26.506s
sys     0m8.259s
```

the improvement works, because the `escape` method is called for every column in every row, so the method call overhead is visible

![grafik](https://github.com/ifsnop/mysqldump-php/assets/120441/9cbd849c-491f-4f3f-bd1d-74052b8c170d)



### PHP Version

PHP 8.1.27

### Operating System

ubuntu 22 lts