### PR TITLE
Remove unnecessary call_user_func() to be faster

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1056,12 +1056,12 @@ class Mysqldump
         $columnTypes = $this->tableColumnTypes[$tableName];
 
         if ($this->transformTableRowCallable) {
-            $row = call_user_func($this->transformTableRowCallable, $tableName, $row);
+            $row = ($this->transformTableRowCallable)($tableName, $row);
         }
 
         foreach ($row as $colName => $colValue) {
             if ($this->transformColumnValueCallable) {
-                $colValue = call_user_func($this->transformColumnValueCallable, $tableName, $colName, $colValue, $row);
+                $colValue = ($this->transformColumnValueCallable)($tableName, $colName, $colValue, $row);
             }
 
             $ret[] = $this->escape($colValue, $columnTypes[$colName]);
@@ -1209,7 +1209,7 @@ class Mysqldump
         $this->endListValues($tableName, $count);
 
         if ($this->infoCallable) {
-            call_user_func($this->infoCallable, 'table', array('name' => $tableName, 'rowCount' => $count));
+            ($this->infoCallable)('table', array('name' => $tableName, 'rowCount' => $count));
         }
     }
 


### PR DESCRIPTION
with a test script of

```php
<?php // test.php

error_reporting(E_ALL);

require_once __DIR__ . '/vendor/autoload.php';

use Ifsnop\Mysqldump as IMysqldump;

$date = date('Ymd');
$dumpSettings = array(
    'compress' => IMysqldump\Mysqldump::NONE,
    'no-data' => false,
    'add-drop-table' => true,
    'single-transaction' => true,
    'lock-tables' => false,
    'add-locks' => true,
    'extended-insert' => true,
    'disable-foreign-keys-check' => true,
    'skip-triggers' => false,
    'add-drop-trigger' => true,
    'databases' => true,
    'add-drop-database' => true,
    'hex-blob' => true,
    'include-tables' => array('my-table'), // add a table name here
);

$dump = new IMysqldump\Mysqldump("mysql:host=192.168.54.10:33065;dbname=clx_erp", "clxerp_user", "P8_Zyv3_Z3-S1", $dumpSettings);
$dump->setTransformTableRowHook(function ($tableName, $row) {
    return $row;
});
$dump->start("backup$date.sql");
```

before this PR
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test2.php

real    0m13.046s
user    0m9.917s
sys     0m2.003s
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test2.php

real    0m13.027s
user    0m9.838s
sys     0m2.144s
```

after this PR
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test2.php

real    0m12.648s
user    0m9.613s
sys     0m1.994s

mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test2.php

real    0m12.883s
user    0m9.838s
sys     0m2.008s
```