### PR TITLE
Faster dump by less tiny writes()

### DIFF
--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1175,7 +1175,7 @@ class Mysqldump
         $ignore = $this->dumpSettings['insert-ignore'] ? '  IGNORE' : '';
 
         $count = 0;
-	$line = '';
+        $line = '';
         foreach ($resultSet as $row) {
             $count++;
             $vals = $this->prepareColumnValues($tableName, $row);
@@ -1196,7 +1196,7 @@ class Mysqldump
                     !$this->dumpSettings['extended-insert']) {
                 $onlyOnce = true;
                 $this->compressManager->write($line . ";".PHP_EOL);
-		$line = '';
+                $line = '';
             }
         }
         $resultSet->closeCursor();

--- a/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -1175,35 +1175,34 @@ class Mysqldump
         $ignore = $this->dumpSettings['insert-ignore'] ? '  IGNORE' : '';
 
         $count = 0;
+	$line = '';
         foreach ($resultSet as $row) {
             $count++;
             $vals = $this->prepareColumnValues($tableName, $row);
             if ($onlyOnce || !$this->dumpSettings['extended-insert']) {
                 if ($this->dumpSettings['complete-insert']) {
-                    $lineSize += $this->compressManager->write(
-                        "INSERT$ignore INTO `$tableName` (".
+                    $line .= "INSERT$ignore INTO `$tableName` (".
                         implode(", ", $colNames).
                         ") VALUES (".implode(",", $vals).")"
-                    );
+                    ;
                 } else {
-                    $lineSize += $this->compressManager->write(
-                        "INSERT$ignore INTO `$tableName` VALUES (".implode(",", $vals).")"
-                    );
+                    $line .= "INSERT$ignore INTO `$tableName` VALUES (".implode(",", $vals).")";
                 }
                 $onlyOnce = false;
             } else {
-                $lineSize += $this->compressManager->write(",(".implode(",", $vals).")");
+                $line .= ",(".implode(",", $vals).")";
             }
-            if (($lineSize > $this->dumpSettings['net_buffer_length']) ||
+            if ((strlen($line) > $this->dumpSettings['net_buffer_length']) ||
                     !$this->dumpSettings['extended-insert']) {
                 $onlyOnce = true;
-                $lineSize = $this->compressManager->write(";".PHP_EOL);
+                $this->compressManager->write($line . ";".PHP_EOL);
+		$line = '';
             }
         }
         $resultSet->closeCursor();
 
-        if (!$onlyOnce) {
-            $this->compressManager->write(";".PHP_EOL);
+        if ($line !== '') {
+            $this->compressManager->write($line. ";".PHP_EOL);
         }
 
         $this->endListValues($tableName, $count);


### PR DESCRIPTION
while writing the dump the script is doing millions of tiny writes().

after this PR we are buffering the contents within a string a do the write only after we reached the net-buffer-length.
this means we are doing waaaay less IO calls.

before this PR:
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test2.php

real    0m14.194s
user    0m10.762s
sys     0m2.340s
```

after this PR
```
mstaab@mst22:/cluster/www/www/www/mysqldump-php$ time php test2.php

real    0m7.492s
user    0m6.403s
sys     0m0.204s
```

which is now 40-50% faster 🚀 